### PR TITLE
Add fuzzing support to project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,29 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  discover-fuzz-tests:
+    name: Discover Fuzz Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tests: ${{ steps.find-tests.outputs.tests }}
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Find fuzz tests
+        id: find-tests
+        run: |
+          TESTS=$(grep -h '^func Fuzz' *_test.go | sed 's/func \(Fuzz[^(]*\).*/\1/' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "tests=$TESTS" >> $GITHUB_OUTPUT
+
   fuzz:
     name: Fuzz
     runs-on: ubuntu-latest
@@ -69,14 +92,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fuzz-test:
-          - FuzzAddSpanTags:.
-          - FuzzAddSpanEvents:.
-          - FuzzFailSpan:.
-          - FuzzNewSpan:.
-          - FuzzWithServiceName:.
-          - FuzzWithServiceVersion:.
-          - FuzzWithSpanExporterEndpoint:.
+        fuzz-test: ${{ fromJson(needs.discover-fuzz-tests.outputs.tests) }}
+    needs: discover-fuzz-tests
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -93,7 +110,7 @@ jobs:
           go-version: 1.25.x
 
       - name: Run fuzz test
-        run: make fuzz-single FUZZ_TEST="${{ matrix.fuzz-test }}"
+        run: make fuzz FUZZ_TEST="${{ matrix.fuzz-test }}"
 
   release:
     name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,40 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        fuzz-test:
+          - FuzzAddSpanTags:.
+          - FuzzAddSpanEvents:.
+          - FuzzFailSpan:.
+          - FuzzNewSpan:.
+          - FuzzWithServiceName:.
+          - FuzzWithServiceVersion:.
+          - FuzzWithSpanExporterEndpoint:.
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: 1.25.x
+
+      - name: Run fuzz test
+        run: make fuzz-single FUZZ_TEST="${{ matrix.fuzz-test }}"
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt lint test test-coverage build clean
+.PHONY: help fmt lint test test-coverage build clean fuzz fuzz-single
 
 # Default target
 help:
@@ -7,6 +7,8 @@ help:
 	@echo "  make lint           - Run golangci-lint"
 	@echo "  make test           - Run tests"
 	@echo "  make test-coverage  - Run tests with coverage"
+	@echo "  make fuzz           - Run all fuzz tests"
+	@echo "  make fuzz-single    - Run single fuzz test (usage: make fuzz-single FUZZ_TEST=FuzzName:package)"
 	@echo "  make build          - Build the project"
 	@echo "  make clean          - Clean build artifacts"
 
@@ -44,4 +46,24 @@ clean:
 	@echo "Cleaning build artifacts..."
 	@rm -f coverage.out
 	@go clean ./...
+	@echo "Done!"
+
+fuzz:
+	@echo "Running fuzz tests..."
+	@go test -fuzz=FuzzAddSpanTags -fuzztime=30s .
+	@go test -fuzz=FuzzAddSpanEvents -fuzztime=30s .
+	@go test -fuzz=FuzzFailSpan -fuzztime=30s .
+	@go test -fuzz=FuzzNewSpan -fuzztime=30s .
+	@go test -fuzz=FuzzWithServiceName -fuzztime=30s .
+	@go test -fuzz=FuzzWithServiceVersion -fuzztime=30s .
+	@go test -fuzz=FuzzWithSpanExporterEndpoint -fuzztime=30s .
+	@echo "Done!"
+
+fuzz-single:
+	@echo "Running single fuzz test: $(FUZZ_TEST)..."
+	@FUZZ_PARTS=$$(echo $(FUZZ_TEST) | tr ':' ' '); \
+	set -- $$FUZZ_PARTS; \
+	FUZZ_NAME=$$1; \
+	FUZZ_PKG=$${2:-.}; \
+	go test -fuzz=$$FUZZ_NAME -fuzztime=30s $$FUZZ_PKG
 	@echo "Done!"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt lint test test-coverage build clean fuzz fuzz-single
+.PHONY: help fmt lint test test-coverage build clean fuzz
 
 # Default target
 help:
@@ -7,8 +7,7 @@ help:
 	@echo "  make lint           - Run golangci-lint"
 	@echo "  make test           - Run tests"
 	@echo "  make test-coverage  - Run tests with coverage"
-	@echo "  make fuzz           - Run all fuzz tests"
-	@echo "  make fuzz-single    - Run single fuzz test (usage: make fuzz-single FUZZ_TEST=FuzzName:package)"
+	@echo "  make fuzz           - Run all fuzz tests (or specific test with FUZZ_TEST=FuzzName)"
 	@echo "  make build          - Build the project"
 	@echo "  make clean          - Clean build artifacts"
 
@@ -49,21 +48,15 @@ clean:
 	@echo "Done!"
 
 fuzz:
-	@echo "Running fuzz tests..."
-	@go test -fuzz=FuzzAddSpanTags -fuzztime=30s .
-	@go test -fuzz=FuzzAddSpanEvents -fuzztime=30s .
-	@go test -fuzz=FuzzFailSpan -fuzztime=30s .
-	@go test -fuzz=FuzzNewSpan -fuzztime=30s .
-	@go test -fuzz=FuzzWithServiceName -fuzztime=30s .
-	@go test -fuzz=FuzzWithServiceVersion -fuzztime=30s .
-	@go test -fuzz=FuzzWithSpanExporterEndpoint -fuzztime=30s .
+ifdef FUZZ_TEST
+	@echo "Running fuzz test: $(FUZZ_TEST)..."
+	@go test -run=^$$ -fuzz=$(FUZZ_TEST) -fuzztime=30s .
 	@echo "Done!"
-
-fuzz-single:
-	@echo "Running single fuzz test: $(FUZZ_TEST)..."
-	@FUZZ_PARTS=$$(echo $(FUZZ_TEST) | tr ':' ' '); \
-	set -- $$FUZZ_PARTS; \
-	FUZZ_NAME=$$1; \
-	FUZZ_PKG=$${2:-.}; \
-	go test -fuzz=$$FUZZ_NAME -fuzztime=30s $$FUZZ_PKG
+else
+	@echo "Running all fuzz tests..."
+	@for test in $$(grep -h '^func Fuzz' *_test.go | sed 's/func \(Fuzz[^(]*\).*/\1/'); do \
+		echo "Running $$test..."; \
+		go test -run=^$$ -fuzz=$$test -fuzztime=30s . || exit 1; \
+	done
 	@echo "Done!"
+endif

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,165 @@
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// FuzzAddSpanTags tests the AddSpanTags function with arbitrary string inputs
+func FuzzAddSpanTags(f *testing.F) {
+	f.Add("key1", "value1")
+	f.Add("", "")
+	f.Add("user.id", "12345")
+	f.Add("http.method", "GET")
+
+	f.Fuzz(func(t *testing.T, key, value string) {
+		_, span := noop.NewTracerProvider().Tracer("test").Start(context.Background(), "test")
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("AddSpanTags panicked with key=%q, value=%q: %v", key, value, r)
+			}
+		}()
+
+		tags := map[string]string{key: value}
+		AddSpanTags(span, tags)
+	})
+}
+
+// FuzzAddSpanEvents tests the AddSpanEvents function with arbitrary string inputs
+func FuzzAddSpanEvents(f *testing.F) {
+	f.Add("event1", "key1", "value1")
+	f.Add("", "", "")
+	f.Add("cache.hit", "cache.key", "user:123")
+	f.Add("database.query", "query", "SELECT * FROM users")
+
+	f.Fuzz(func(t *testing.T, name, key, value string) {
+		_, span := noop.NewTracerProvider().Tracer("test").Start(context.Background(), "test")
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("AddSpanEvents panicked with name=%q, key=%q, value=%q: %v", name, key, value, r)
+			}
+		}()
+
+		events := map[string]string{key: value}
+		AddSpanEvents(span, name, events)
+	})
+}
+
+// FuzzFailSpan tests the FailSpan function with arbitrary message strings
+func FuzzFailSpan(f *testing.F) {
+	f.Add("error occurred")
+	f.Add("")
+	f.Add("database connection failed")
+	f.Add("invalid input provided")
+
+	f.Fuzz(func(t *testing.T, msg string) {
+		_, span := noop.NewTracerProvider().Tracer("test").Start(context.Background(), "test")
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("FailSpan panicked with msg=%q: %v", msg, r)
+			}
+		}()
+
+		FailSpan(span, msg)
+	})
+}
+
+// FuzzNewSpan tests the NewSpan function with arbitrary span names
+func FuzzNewSpan(f *testing.F) {
+	f.Add("operation")
+	f.Add("")
+	f.Add("http.request")
+	f.Add("database.query")
+
+	f.Fuzz(func(t *testing.T, name string) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("NewSpan panicked with name=%q: %v", name, r)
+			}
+		}()
+
+		ctx, span := NewSpan(context.Background(), name, nil)
+		if ctx == nil {
+			t.Error("NewSpan returned nil context")
+		}
+		if span == nil {
+			t.Error("NewSpan returned nil span")
+		}
+		span.End()
+	})
+}
+
+// FuzzWithServiceName tests the WithServiceName option with arbitrary service names
+func FuzzWithServiceName(f *testing.F) {
+	f.Add("my-service")
+	f.Add("")
+	f.Add("api-gateway")
+	f.Add("user-service")
+
+	f.Fuzz(func(t *testing.T, name string) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("WithServiceName panicked with name=%q: %v", name, r)
+			}
+		}()
+
+		var c Config
+		opt := WithServiceName(name)
+		opt(&c)
+
+		if c.ServiceName != name {
+			t.Errorf("Expected ServiceName=%q, got %q", name, c.ServiceName)
+		}
+	})
+}
+
+// FuzzWithServiceVersion tests the WithServiceVersion option with arbitrary versions
+func FuzzWithServiceVersion(f *testing.F) {
+	f.Add("1.0.0")
+	f.Add("")
+	f.Add("v2.3.4-beta")
+	f.Add("latest")
+
+	f.Fuzz(func(t *testing.T, version string) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("WithServiceVersion panicked with version=%q: %v", version, r)
+			}
+		}()
+
+		var c Config
+		opt := WithServiceVersion(version)
+		opt(&c)
+
+		if c.ServiceVersion != version {
+			t.Errorf("Expected ServiceVersion=%q, got %q", version, c.ServiceVersion)
+		}
+	})
+}
+
+// FuzzWithSpanExporterEndpoint tests the WithSpanExporterEndpoint option with arbitrary URLs
+func FuzzWithSpanExporterEndpoint(f *testing.F) {
+	f.Add("http://localhost:4317")
+	f.Add("")
+	f.Add("https://otel-collector:4318")
+	f.Add("grpc://collector.example.com:4317")
+
+	f.Fuzz(func(t *testing.T, url string) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("WithSpanExporterEndpoint panicked with url=%q: %v", url, r)
+			}
+		}()
+
+		var c Config
+		opt := WithSpanExporterEndpoint(url)
+		opt(&c)
+
+		if c.SpanExporterEndpoint != url {
+			t.Errorf("Expected SpanExporterEndpoint=%q, got %q", url, c.SpanExporterEndpoint)
+		}
+	})
+}
+


### PR DESCRIPTION
This commit adds comprehensive fuzzing tests and CI integration to address the OpenSSF Scorecard fuzzing requirement.

Changes:
- Add fuzz_test.go with 7 fuzz tests covering key functions:
  - FuzzAddSpanTags: Tests span tagging with arbitrary inputs
  - FuzzAddSpanEvents: Tests span events with arbitrary inputs
  - FuzzFailSpan: Tests span failure handling
  - FuzzNewSpan: Tests span creation with arbitrary names
  - FuzzWithServiceName: Tests service name configuration
  - FuzzWithServiceVersion: Tests service version configuration
  - FuzzWithSpanExporterEndpoint: Tests endpoint configuration

- Update Makefile with fuzzing targets:
  - make fuzz: Runs all fuzz tests for 30 seconds each
  - make fuzz-single: Runs individual fuzz test with FUZZ_TEST parameter

- Update CI workflow to run fuzz tests in matrix:
  - Added dedicated fuzz job with fail-fast: false
  - Each fuzz test runs in parallel as a matrix job
  - Uses ubuntu-latest with Go 1.25.x

This implementation follows the pattern from observability-log and ensures all key public functions are tested against arbitrary inputs to catch potential panics or unexpected behavior.